### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,9 +770,9 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 
 ### What is the minimum time Interval for the data that Amazon CloudWatch receives and aggregates?
 
-- [x] One second.
+- [ ] One second.
 - [ ] Five seconds.
-- [ ] One minute.
+- [x] One minute.
 - [ ] Three minutes.
 - [ ] Five minutes.
 
@@ -791,9 +791,9 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 
 - [ ] A video transcoding pipeline running on EC2 using SQS to distribute tasks and Auto Scaling to adjust the number of nodes depending on the length of the queue. EBS volumes to host videos and EBS snapshots to incrementally backup original files after a few days. CloudFront to serve HLS transcoded videos from EC2.
 - [ ] Elastic Transcoder to transcode original high-resolution MP4 videos to HL.
-- [x] EBS volumes to host videos and EBS snapshots to incrementally backup original files after a few days. CloudFront to serve HLS transcoded videos from EC2.
+- [ ] EBS volumes to host videos and EBS snapshots to incrementally backup original files after a few days. CloudFront to serve HLS transcoded videos from EC2.
 - [ ] Elastic Transcoder to transcode original high-resolution MP4 videos to HL.
-- [ ] Amazon S3 to host videos with Lifecycle Management to archive original files to Glacier after a few days. CloudFront to serve HLStranscoded videos from S3.
+- [x] Amazon S3 to host videos with Lifecycle Management to archive original files to Glacier after a few days. CloudFront to serve HLStranscoded videos from S3.
 - [ ] A video transcoding pipeline running on EC2 using SQS to distribute tasks and Auto Scaling to adjust the number of nodes depending on the length of the queue. S3 to host videos with Lifecycle Management to archive all files to Glacier after a few days. CloudFront to serve HLS transcoded videos from Glacier.
 
 **[⬆ Back to Top](#table-of-contents)**


### PR DESCRIPTION
Update correct answers for video streaming and CloudWatch interval questions

-While CloudWatch does offer the ability to increase the granularity to one-second intervals, this feature is part of detailed monitoring and is not enabled by default. Detailed monitoring is also typically associated with additional costs.